### PR TITLE
chore: loosen react version for peer deps

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -18,7 +18,7 @@
     "build": "webpack --config webpack.config.js"
   },
   "peerDependencies": {
-    "react": "^16.6.3"
+    "react": ">=16.6.3"
   },
   "devDependencies": {
     "webpack": "^4.17.1"


### PR DESCRIPTION
I created this pull request because recent versions of NPM fail to install packages when peer dependencies have a conflict. The latest major version of React is 18, but this package only allows version 16.x as a peer dependency.